### PR TITLE
Added logging capability

### DIFF
--- a/JetCurry.py
+++ b/JetCurry.py
@@ -29,7 +29,7 @@ np.seterr(all='ignore')
 def imagesqrt(image, scale_min, scale_max):
     '''
     Algorithm Courtesy of Min-Su Shin (msshin @ umich.edu)
-    Modified by Katie Kosak 07/02/2015 to fit the needsof Hubble Data for
+    Modified by Katie Kosak 07/02/2015 to fit the needs of Hubble Data for
     Dr. Perlman and Dr. Avachat.
 
     Arguments:
@@ -264,7 +264,7 @@ def RunMCMC2(s, eta, d0, theta, a, b, c, e, ind, output_directory, filename):
                         init.append(initial_d[m])
                         pos.append(init)
 
-    ndim, nwalkers, nsteps = 5, float(shape(pos)[0]), 50
+    ndim, nwalkers, nsteps = 5, int(shape(pos)[0]), 50
 
     def lnlike(v):
         '''

--- a/JetCurryGui.py
+++ b/JetCurryGui.py
@@ -1,5 +1,8 @@
 import os
-import tkinter as tk
+try:
+    import tkinter as tk # python 3
+except ImportError:
+    import Tkinter as tk # python 2
 from PIL import Image, ImageTk
 from astropy.io import fits
 import matplotlib

--- a/JetCurryInit.py
+++ b/JetCurryInit.py
@@ -1,0 +1,38 @@
+import sys
+import imp
+
+pythonVersion = sys.version_info[0]
+if pythonVersion == 3:
+  tk = "tkinter"
+else:
+  tk = "Tkinter"
+
+def check_modules():
+  # Required modules
+  modules = ['emcee',
+            'multiprocessing',
+            'scipy',
+            'numpy',
+            'astropy',
+            'matplotlib',
+            'math',
+            'numpy',
+            'pylab',
+            'argparse',
+            'glob',
+            'PIL',
+            tk]
+
+  '''
+  Try to import required modules.
+  If a module can't be imported then print module name and exit
+  '''
+  missing_modules = []
+
+  for module in modules:
+    try:
+      imp.find_module(module)
+    except ImportError:
+      missing_modules.append(module)
+
+  return missing_modules

--- a/JetCurryInit.py
+++ b/JetCurryInit.py
@@ -21,6 +21,7 @@ def check_modules():
             'argparse',
             'glob',
             'PIL',
+            'itertools',
             tk]
 
   '''

--- a/JetCurryLogger.py
+++ b/JetCurryLogger.py
@@ -1,0 +1,51 @@
+import sys
+import logging
+
+pythonVersion = sys.version_info[0]
+
+def write_log(logfile, logLevel, message, logMode):
+	FORMAT = "%(asctime)s - %(levelname)s: %(message)s"
+	if pythonVersion == 3:
+		if (logMode is True or logMode == 'True'):
+			logging.basicConfig(
+    			level=logging.INFO,
+    			format=FORMAT,
+    			handlers=[
+        			logging.FileHandler(logfile),
+        			logging.StreamHandler(sys.stdout)
+    			])
+		else:
+			logging.basicConfig(
+                        level=logging.INFO,
+                        format=FORMAT,
+                        handlers=[
+							logging.FileHandler(logfile)
+			])
+
+		logger = logging.getLogger()
+		if logLevel == 'info':
+			logger.info(message)
+		elif logLevel =='critical':
+			logger.critical(message)
+		else:
+			logger.error(message)
+	else:
+		logger = logging.getLogger()
+		logFormatter = logging.Formatter(FORMAT)
+		logger.setLevel(logging.INFO)
+
+		fileHandler = logging.FileHandler(logfile)
+		fileHandler.setFormatter(logFormatter)
+		logger.addHandler(fileHandler)
+
+		if (logMode is True or logMode == 'True'):
+			consoleHandler = logging.StreamHandler(sys.stdout)
+			consoleHandler.setFormatter(logFormatter)
+			logger.addHandler(consoleHandler)
+
+		if logLevel == 'info':
+			logger.info(message)
+		elif logLevel =='critical':
+			logger.critical(message)
+		else:
+			logger.error(message)

--- a/JetCurryMain.py
+++ b/JetCurryMain.py
@@ -37,6 +37,7 @@ import argparse
 import glob
 import JetCurryGui
 from JetCurryLogger import write_log
+import itertools
 
 
 # Create command line argument parser
@@ -94,17 +95,20 @@ for file in files:
     filename = os.path.splitext(file)[0]
     filename = os.path.basename(filename)
     output_directory = output_directory_default + filename + '/'
+
+    # create output directory
+    # if directory already exists, append name with _N
     if not os.path.exists(output_directory):
         os.makedirs(output_directory)
+    else:
+        for i in itertools.count(1):
+            output_directory = output_directory_default + filename + '_' + str(i) + '/'
+            if not os.path.exists(output_directory):
+                os.makedirs(output_directory)
+                break
 
     # create log file
-    # if log file already exists, append filename with _N 
     log_filename = output_directory + filename + '.log'
-    if os.path.isfile(log_filename):
-        for x in range(1,11):
-            log_filename = output_directory + filename + '_' + str(x) + '.log'
-            if not os.path.isfile(log_filename):
-                break
 
     curry = JetCurryGui.JetCurryGui(file)
     upstream_bounds = np.array(
@@ -117,7 +121,7 @@ for file in files:
         os.sys.exit()
 
     write_log(log_filename, 'info', 'Using filename: ' + filename + '.fits', args.debug)
-    write_log(log_filename, 'info', 'Output directory set to ' + output_directory_default, args.debug)
+    write_log(log_filename, 'info', 'Output directory set to ' + output_directory, args.debug)
     write_log(log_filename, 'info', 'Upstream bound is: ' + str(upstream_bounds), args.debug)
     write_log(log_filename, 'info', 'Downstream bound is: ' + str(downstream_bounds), args.debug)
     

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Models the 3D geometry of AGN jets.
 
-JetCurry, Copyright 2017. Katie Kosak. Eric Perlman. Copyright Details: GPL.txt
+JetCurry, Copyright 2017. Andrew Colson. Katie Kosak. Eric Perlman. Copyright Details: GPL.txt
 
-Last Edited: March 2018. Questions: Contact Katie Kosak,  [katie.kosak@gmail.com](mailto:katie.kosak@gmail.com)
+Last Edited: May 2019. Questions: Contact Katie Kosak,  [katie.kosak@gmail.com](mailto:katie.kosak@gmail.com)
 
 
 ## Usage
@@ -17,12 +17,16 @@ python JetCurryMain.py input [-out_dir]
 
 **Optional arguments** 
 
-**-out\_dir**: full or relative path to save output files.  Output directory is created if it doesn't exist. Default output is current working directory if -out\_dir is not specified. 
+**-out\_dir**: full or relative path to save output files.  Output directory is created if it doesn't exist. If it already exists then the full path is appended with "\_N" where N is 1 through infinity. Default output is current working directory if -out\_dir is not specified.
+
+**-debug**: enables logging to the console and logfile. Default behavior is to only log to the logfile saved as "inputfilename.log". The logfile is saved to the default or specified output directory. 
 
 **Example**
-> python JetCurryMain.py ./KnotD\_Radio.fits
+> python JetCurryMain.py ./KnotD\_Radio.fits # processes single FITS file and saves data products to the current working directory
 
->  python JetCurryMain.py ./data -out_dir /foo/bar/
+> python JetCurryMain.py ./data -out_dir /foo/bar/ # processes entire ./data directory with data products saved to specified output directory
+
+> python JetCurryMain.py ./KnotD\_Radio.fits -debug # processes single FITS file and logs information to the console and to KnotD\_Radio.log
 
 ## Notes
 
@@ -32,4 +36,4 @@ Data products are organized by the FITS filename. For example, if the output dir
 
 ## TODO
 
-Optimize with cython or numba.
+scipy.interpolate.spline is depreciated in newer versions of SciPy.


### PR DESCRIPTION
Added the -debug command line argument which enables information logging to both the console and log file. Default behavior is to only save to log file.

Example:
`python JetCurryMain.py KnotD_Radio.fits -debug`

The above logs information to the console and creates the log file ./KnotD_Radio/KnotD_Radio.log. Here is a snippet of its contents:

> 2019-05-23 15:58:31,912 - INFO: Using filename: KnotD_Radio.fits
> 2019-05-23 15:58:31,913 - INFO: Output directory set to ./KnotD_Radio/
> 2019-05-23 15:58:31,914 - INFO: Upstream bound is: [29 20]
> 2019-05-23 15:58:31,915 - INFO: Downstream bound is: [81 16]
> 2019-05-23 15:58:31,916 - INFO: Created square root image of data:
> 2019-05-23 15:58:31,917 - INFO: [[0.3109157  0.32176653 0.29817274 ...
>
> 2019-05-23 15:58:31,917 - INFO: Number of sample points: 52
> 2019-05-23 15:58:31,948 - INFO: Successfully calculated the max intensities
> 2019-05-23 15:58:31,951 - INFO: Max intensity at point x:
> 2019-05-23 15:58:31,952 - INFO: [29. 30. 31. 32. 33. ...
> 2019-05-23 15:58:31,954 - INFO: Max intensity at point y:
> 2019-05-23 15:58:31,955 - INFO: [18. 18. 17. 17. 17. ...
>
> 2019-05-23 15:58:31,956 - INFO: Smoothed sample points calculated over the start/stop interval:
> 2019-05-23 15:58:31,958 - INFO: [29.         30.01960784 31.03921569 32.05882353 ...
>
> 2019-05-23 15:58:31,961 - INFO: Interpolated curve using spline fit:
> 2019-05-23 15:58:31,962 - INFO: [18.         17.97897257 16.98140131 17.00509345 ...
>
> 2019-05-23 15:59:36,891 - INFO: MCM1_Parallel passed
> 2019-05-23 16:01:07,609 - INFO: MCMC2_Parallel passed
> 2019-05-23 16:01:08,909 - INFO: Annealing1_Parallel passed
> 2019-05-23 16:01:09,523 - INFO: Annealing2_Parallel passed
> 2019-05-23 16:01:09,611 - INFO: Jet Curry successful for KnotD_Radio.fits
